### PR TITLE
Add usage func

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Static Templ
+
 Build static HTML websites with file based routing, using [templ](https://github.com/a-h/templ)! All components are pre-rendered at build time, and the resulting HTML files can be served using any static file server.
 
 ## Installation
@@ -10,22 +11,33 @@ go install github.com/nokacper24/static-templ@latest
 ## Usage
 
 ```bash
-templ generate
-static-templ -i web/pages
+Usage of static-templ:
+static-templ [options]
+
+Options:
+  -i  Specify input directory (default "web/pages").
+  -o  Specify output directory (default "dist").
+  -f  Run templ fmt.
+  -g  Run templ generate.
+
+Examples:
+  # Specify input and output directories
+  static-templ -i web/demos -o output
+
+  # Specify input directory, run templ generate and output to default directory
+  static-templ -i web/demos -g=true
 ```
-This will generate static html files in `dist` directory. You can specify a different output directory using `-o` flag.
-
-
 
 ## Assumptions
+
 Templ components that will be turned into html files must be **exported**, and take **no arguments**. If these conditions are not met, the component will be ignored. Your components must be in the *input* directory, their path will be mirrored in the *output* directory.
 
 All files other than `.go` and `.templ` files will be copied to the output directory, preserving the directory structure. This allows you to include any assets and reference them using relative paths.
 
 ## Example project
 
-
 ## Background
+
 Templ does support rendering components into files, as shown in their [documentation](https://templ.guide/static-rendering/generating-static-html-files-with-templ/). I wanted to avoid writing code to do so manually for each page.
 
 static-templ creates a script that will render wanted components and write them intoto files, executes it and cleans up after itself.

--- a/main.go
+++ b/main.go
@@ -22,10 +22,11 @@ func main() {
 	var inputDir, outputDir string
 	var runFormat, runGenerate bool
 
-	flag.StringVar(&inputDir, "i", "web/pages", `Specify input directory.`)
-	flag.StringVar(&outputDir, "o", "dist", `Specify output directory.`)
+	flag.StringVar(&inputDir, "i", "web/pages", "Specify input directory.")
+	flag.StringVar(&outputDir, "o", "dist", "Specify output directory.")
 	flag.BoolVar(&runFormat, "f", false, "Run templ fmt.")
 	flag.BoolVar(&runGenerate, "g", false, "Run templ generate.")
+	flag.Usage = usage
 	flag.Parse()
 
 	inputDir = strings.TrimRight(inputDir, "/")
@@ -97,6 +98,25 @@ func main() {
 	if err = os.Remove(getOutputScriptPath()); err != nil {
 		log.Fatal("err removing script file", err)
 	}
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, `Usage of %s:
+%s [options]
+
+Options:
+  -i  Specify input directory (default "web/pages").
+  -o  Specify output directory (default "dist").
+  -f  Run templ fmt.
+  -g  Run templ generate.
+
+Examples:
+  # Specify input and output directories
+  %s -i web/demos -o output
+
+  # Specify input directory, run templ generate and output to default directory
+  %s -i web/demos -g=true
+`, os.Args[0], os.Args[0], os.Args[0], os.Args[0])
 }
 
 func getOutputScriptPath() string {


### PR DESCRIPTION
This PR:

- set a custom `flag.Usage` func documenting all defined command-line flags with examples
- update the **Usage** section on the README.md file