### PR TITLE
add `debug` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,6 @@ All files other than `.go` and `.templ` files will be copied to the output direc
 
 ## Background
 
-Templ does support rendering components into files, as shown in their [documentation](https://templ.guide/static-rendering/generating-static-html-files-with-templ/). I wanted to avoid writing code to do so manually for each page.
+Templ does support rendering components into files, as shown in their [documentation](https://templ.guide/static-rendering/generating-static-html-files-with-templ/). I wanted to avoid manually writing code for each page.
 
-static-templ creates a script that will render wanted components and write them intoto files, executes it and cleans up after itself.
+`static-templ` creates a script that renders the desired components, writes them into files, executes the script, and cleans up afterward.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Options:
   -o  Specify output directory (default "dist").
   -f  Run templ fmt.
   -g  Run templ generate.
+  -d  Keep the generation script after completion for inspection and debugging.
 
 Examples:
   # Specify input and output directories

--- a/main.go
+++ b/main.go
@@ -20,12 +20,13 @@ const (
 
 func main() {
 	var inputDir, outputDir string
-	var runFormat, runGenerate bool
+	var runFormat, runGenerate, debug bool
 
 	flag.StringVar(&inputDir, "i", "web/pages", "Specify input directory.")
 	flag.StringVar(&outputDir, "o", "dist", "Specify output directory.")
 	flag.BoolVar(&runFormat, "f", false, "Run templ fmt.")
 	flag.BoolVar(&runGenerate, "g", false, "Run templ generate.")
+	flag.BoolVar(&debug, "d", false, "Keep the generation script after completion for inspection and debugging.")
 	flag.Usage = usage
 	flag.Parse()
 
@@ -95,8 +96,10 @@ func main() {
 		log.Fatal("err running script", err)
 	}
 
-	if err = os.Remove(getOutputScriptPath()); err != nil {
-		log.Fatal("err removing script file", err)
+	if !debug {
+		if err = os.RemoveAll(outputScriptDirPath); err != nil {
+			log.Fatal("err removing script folder", err)
+		}
 	}
 }
 
@@ -109,6 +112,7 @@ Options:
   -o  Specify output directory (default "dist").
   -f  Run templ fmt.
   -g  Run templ generate.
+  -d  Keep the generation script after completion for inspection and debugging.
 
 Examples:
   # Specify input and output directories


### PR DESCRIPTION
this PR:

- add a new `debug` flag (default to `false`) to keep the generation script after completion. That could be useful for inspection and debugging
- update the `usage` function and the **Usage** section on the `README.md` file
- rephrase a bit the **Background** section on the `README.md` file

