### PR TITLE
feat: add version subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,17 @@ go install github.com/nokacper24/static-templ@latest
 
 ```bash
 Usage of static-templ:
-static-templ [options]
+static-templ [flags] [subcommands]
 
-Options:
+Flags:
   -i  Specify input directory (default "web/pages").
   -o  Specify output directory (default "dist").
   -f  Run templ fmt.
   -g  Run templ generate.
   -d  Keep the generation script after completion for inspection and debugging.
+
+Subcommands:
+  version  Display the version information.
 
 Examples:
   # Specify input and output directories
@@ -27,6 +30,9 @@ Examples:
 
   # Specify input directory, run templ generate and output to default directory
   static-templ -i web/demos -g=true
+
+  # Display the version information
+  static-templ version
 ```
 
 ## Assumptions

--- a/main.go
+++ b/main.go
@@ -148,7 +148,7 @@ func printVersion() {
 	if err != nil {
 		log.Fatalf("Error retrieving module version: %v", err)
 	}
-	fmt.Printf("Version: %s (built with: %s %s)\n", version, templModulePath, templModuleVersion)
+	fmt.Printf("Version: %s (built with %s@%s)\n", version, templModulePath, templModuleVersion)
 }
 
 func getTemplModuleVersion(modulePath string) (string, error) {

--- a/main.go
+++ b/main.go
@@ -11,10 +11,12 @@ import (
 
 	"github.com/nokacper24/static-templ/internal/finder"
 	"github.com/nokacper24/static-templ/internal/generator"
-	"golang.org/x/mod/modfile"
 )
 
-const version = "1.0.0"
+const (
+	version      = "1.0.0"
+	templVersion = "0.2.731"
+)
 
 const (
 	outputScriptDirPath  string = "temp"
@@ -32,7 +34,7 @@ func main() {
 	switch os.Args[1] {
 	case "version", "--version":
 		versionCmd.Parse(os.Args[2:])
-		printVersion()
+		printVersion(version, templVersion)
 		return
 	default:
 		// Continue with existing flag parsing
@@ -148,30 +150,9 @@ Examples:
 `, os.Args[0], os.Args[0], os.Args[0], os.Args[0], os.Args[0])
 }
 
-func printVersion() {
+func printVersion(version, templVersion string) {
 	templModulePath := "github.com/a-h/templ"
-	templModuleVersion, err := getTemplModuleVersion(templModulePath)
-	if err != nil {
-		log.Fatalf("Error retrieving module version: %v", err)
-	}
-	fmt.Printf("Version: %s (built with %s@%s)\n", version, templModulePath, templModuleVersion)
-}
-
-func getTemplModuleVersion(modulePath string) (string, error) {
-	data, err := os.ReadFile("go.mod")
-	if err != nil {
-		return "", err
-	}
-	modFile, err := modfile.Parse("go.mod", data, nil)
-	if err != nil {
-		return "", err
-	}
-	for _, req := range modFile.Require {
-		if req.Mod.Path == modulePath {
-			return req.Mod.Version, nil
-		}
-	}
-	return "", fmt.Errorf("module %s not found in go.mod", modulePath)
+	fmt.Printf("Version: %s (built with %s@v%s)\n", version, templModulePath, templVersion)
 }
 
 func clearAndCreateDir(dir string) error {

--- a/main.go
+++ b/main.go
@@ -124,14 +124,17 @@ func main() {
 
 func usage() {
 	fmt.Fprintf(os.Stderr, `Usage of %s:
-%s [options]
+%s [flags] [subcommands]
 
-Options:
+Flags:
   -i  Specify input directory (default "web/pages").
   -o  Specify output directory (default "dist").
   -f  Run templ fmt.
   -g  Run templ generate.
   -d  Keep the generation script after completion for inspection and debugging.
+
+Subcommands:
+  version  Display the version information.
 
 Examples:
   # Specify input and output directories
@@ -139,7 +142,10 @@ Examples:
 
   # Specify input directory, run templ generate and output to default directory
   %s -i web/demos -g=true
-`, os.Args[0], os.Args[0], os.Args[0], os.Args[0])
+
+  # Display the version information
+  %s version
+`, os.Args[0], os.Args[0], os.Args[0], os.Args[0], os.Args[0])
 }
 
 func printVersion() {


### PR DESCRIPTION
This PR:

- implements the `version` subcommand as per #9 

By running `static-templ version` or `static-templ --version`, the following message will be displayed:

```bash
Version: 1.0.0 (built with github.com/a-h/templ@v0.2.731)
```

templ version is hardcoded and _must be updated on new releases_. I know, it is not preferred approach but the simpler, for sure. I took this approach to avoid using something like `go build -ldflags="-X main.templVersion=$(go list -m -f '{{.Version}}' github.com/a-h/templ)" -o static-templ .`

- update the `usage` function and the "Usage" section on the `README.md` file