### PR TITLE
fix: waiting for templ commands to complete

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -123,19 +123,22 @@ func newFilePath(opriginalDirPath string, oldPrefix string, newPrefix string, fi
 }
 
 // Run the fmt command
-func RunTemplFmt(files []string) error {
+func RunTemplFmt(files []string, done chan<- struct{}) error {
 	args := fmtcmd.Arguments{
 		Files: files,
 	}
-	return fmtcmd.Run(logger, os.Stdin, os.Stdout, args)
+	err := fmtcmd.Run(logger, os.Stdin, os.Stdout, args)
+	done <- struct{}{}
+	return err
 }
 
 // Run the generate command
-func RunTemplGenerate() error {
+func RunTemplGenerate(done chan<- struct{}) error {
 	args := generatecmd.Arguments{
 		Path: ".",
 	}
-
 	ctx := context.Background()
-	return generatecmd.Run(ctx, logger, args)
+	err := generatecmd.Run(ctx, logger, args)
+	done <- struct{}{}
+	return err
 }


### PR DESCRIPTION
This PR fixes #11 

The proposed solution is to use channels to signal the completion of `generator.RunTemplFmt` and `generator.RunTemplGenerate`, ensuring they are fully executed before proceeding.

Changes include:

- Modify the `generator.RunTemplFmt` and `generator.RunTemplGenerate` functions to accept a done channel and signal their completion.
- Update the main function to wait for these signals before proceeding, ensuring that the templ commands have completed their tasks.
- Run `finder.FindFunctionsInFiles(groupedFiles.TemplGoFiles)` again to include `*_templ.go` files after the completion of the `generator.RunTemplGenerate` function.
