### PR TITLE
refactor: improve code quality

### DIFF
--- a/internal/finder/finder.go
+++ b/internal/finder/finder.go
@@ -58,7 +58,7 @@ func findAllFiles(root string) (filePaths, error) {
 	return paths, nil
 }
 
-// Goes throught the file paths provided and finds all exported fucntrions that take 0 parameters.
+// Goes through the file paths provided and finds all exported fucntrions that take 0 parameters.
 // Files provided must be valid Go source files.
 func FindFunctionsInFiles(files filePaths) ([]FunctionToCall, error) {
 	var funcs []FunctionToCall
@@ -128,7 +128,7 @@ func (f *FunctionToCall) HtmlFileName() string {
 	return fmt.Sprintf("%s.html", slugified)
 }
 
-type groupedFiles struct {
+type GroupedFiles struct {
 	TemplGoFiles filePaths // "_templ.go" files
 	TemplFiles   filePaths // ".templ" files
 	GoFiles      filePaths // ".go" files, excluding "_templ.go"
@@ -136,8 +136,8 @@ type groupedFiles struct {
 }
 
 // Groups files provided into TemplGoFiles ("_templ.go"), TemplFiles (".templ"), GoFiles (other ".go" files) and OtherFiles.
-func (f *filePaths) toGroupedFiles() *groupedFiles {
-	var gf groupedFiles
+func (f *filePaths) toGroupedFiles() *GroupedFiles {
+	var gf GroupedFiles
 	for _, fp := range *f {
 		if fp[len(fp)-9:] == "_templ.go" {
 			gf.TemplGoFiles = append(gf.TemplGoFiles, fp)
@@ -155,7 +155,7 @@ func (f *filePaths) toGroupedFiles() *groupedFiles {
 // Finds paths to all files in the given directory and all its subdirecotries.
 //
 // Groups the files into groupedFiles type, includes TemplGoFiles ("_templ.go"), TemplFiles (".templ"), GoFiles (other ".go" files) and OtherFiles.
-func FindFilesInDir(root string) (*groupedFiles, error) {
+func FindFilesInDir(root string) (*GroupedFiles, error) {
 	allFiles, err := findAllFiles(root)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR improve the overall quality  code measures (`gofmt`, `go vet`, `go lint` and `gocyclo`) reported by [goreportcard](https://github.com/gojp/goreportcard) and [golangci-lint](https://golangci-lint.run/).

### Key Changes

refactor `main.go` by breaking down the code into smaller functions to manage the logic more efficiently. 

- Extract flag parsing into a function.
- Extract the version command handling into a function.
- Extract the directory preparation logic into a function.
- Extract the format and generate commands into separate functions.
- Extract the main logic based on the mode into separate functions.

### Current Implementation

**goreportcard-cli**

By running `goreportcard-cli -v` on the actual implementation, the results are

```bash
Grade ........... A+ 97.1%
Files .................. 4
Issues ................. 2
gofmt ............... 100%
go_vet .............. 100%
gocyclo .............. 75%
	main.go
		Line 29: warning: cyclomatic complexity 21 of function main() is high (> 15) (gocyclo)
ineffassign ......... 100%
license ............. 100%
misspell ............. 75%
	internal/finder/finder.go
		Line 61: warning: "throught" is a misspelling of "thought" (misspell)
```

**golangci-lint**

By running  `golangci-lint run ./...` using the following `.golangci.yml` configuration

```yaml
linters:
  enable:
    - errcheck
    - gofmt
    - govet
    - staticcheck
    - unused
    - gocyclo
linters-settings:
  gofmt:
    module-path: github.com/nokacper24/static-templ
    rewrite-rules:
      - pattern: 'interface{}'
        replacement: 'any'
      - pattern: 'a[b:len(a)]'
        replacement: 'a[b:]'
  gocyclo:
    # Minimal code complexity to report.
    # Default: 30 (but we recommend 10-20)
    min-complexity: 10

```

```bash
main.go:38:19: Error return value of `versionCmd.Parse` is not checked (errcheck)
		versionCmd.Parse(os.Args[2:])
		                ^
main.go:28:1: cyclomatic complexity 21 of func `main` is high (> 10) (gocyclo)
```

### PR Implementation

**goreportcard-cli**

```bash
Grade .......... A+ 100.0%
Files .................. 4
Issues ................. 0
gofmt ............... 100%
go_vet .............. 100%
gocyclo ............. 100%
ineffassign ......... 100%
license ............. 100%
misspell ............ 100%
```

**golangci-lint**

none -> all good