### PR TITLE
docs: add badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Static Templ
 
+[![release](https://github.com/nokacper24/static-templ/actions/workflows/release.yml/badge.svg)](https://github.com/nokacper24/static-templ/actions/workflows/release.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/nokacper24/static-templ)](https://goreportcard.com/report/github.com/nokacper24/static-templ)
+[![Version](https://badge.fury.io/gh/nokacper24%2Fstatic-templ.svg)](https://badge.fury.io/gh/nokacper24%2Fstatic-templ)
+[![Go Reference](https://pkg.go.dev/badge/github.com/nokacper24/static-templ/.svg)](https://pkg.go.dev/github.com/nokacper24/static-templ/)
+[![License](https://img.shields.io/github/license/nokacper24/static-templ)](https://github.com/nokacper24/static-templ/blob/main/LICENSE)
+
 Build static HTML websites with file based routing, using [templ](https://github.com/a-h/templ)! All components are pre-rendered at build time, and the resulting HTML files can be served using any static file server.
 
 ## Installation


### PR DESCRIPTION
This PR adds badges to the README.md file for quick access to relevant metadata.

Added Badges:

- Release Action – Shows the latest GitHub Actions release status
- Go Report Card – Displays code quality metrics
- Version – Indicates the current release version via Badge Fury
- Go Reference – Links to documentation on pkg.go.dev
- License